### PR TITLE
Issue 52 wrong msg bldg template

### DIFF
--- a/controllers/entityController.go
+++ b/controllers/entityController.go
@@ -243,9 +243,10 @@ var CreateEntity = func(w http.ResponseWriter, r *http.Request) {
 
 	//Check if category and endpoint match, only for objects
 	if i != u.OBJTMPL && i != u.BLDGTMPL && i != u.ROOMTMPL {
-		if entity["category"] != entStr {
+		//Stray objects don't always conform to the JSON standard
+		if entity["category"] != entStr && entStr != "stray_device" && entStr != "stray_sensor" {
 			w.WriteHeader(http.StatusBadRequest)
-			u.Respond(w, u.Message(false, "Category in request body does not correspond with endpoint"))
+			u.Respond(w, u.Message(false, "Category in request body does not correspond with desired object in endpoint"))
 			u.ErrLog("Cannot create invalid object", "CREATE "+mux.Vars(r)["entity"], "", r)
 			return
 		}

--- a/controllers/entityController.go
+++ b/controllers/entityController.go
@@ -241,10 +241,9 @@ var CreateEntity = func(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	//Check if category and endpoint match, only for objects
-	if i != u.OBJTMPL && i != u.BLDGTMPL && i != u.ROOMTMPL {
-		//Stray objects don't always conform to the JSON standard
-		if entity["category"] != entStr && entStr != "stray_device" && entStr != "stray_sensor" {
+	//Check if category and endpoint match, except for templates and strays
+	if i < u.ROOMTMPL {
+		if entity["category"] != entStr {
 			w.WriteHeader(http.StatusBadRequest)
 			u.Respond(w, u.Message(false, "Category in request body does not correspond with desired object in endpoint"))
 			u.ErrLog("Cannot create invalid object", "CREATE "+mux.Vars(r)["entity"], "", r)

--- a/controllers/entityController.go
+++ b/controllers/entityController.go
@@ -429,6 +429,8 @@ var GetEntity = func(w http.ResponseWriter, r *http.Request) {
 			message = "successfully got room_template"
 		case u.OBJTMPL:
 			message = "successfully got obj_template"
+		case u.BLDGTMPL:
+			message = "successfully got building_template"
 		default:
 			message = "successfully got object"
 		}

--- a/controllers/entityController.go
+++ b/controllers/entityController.go
@@ -241,11 +241,14 @@ var CreateEntity = func(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	//Hard Code the 'category'
-	//for all objects that are
-	//not obj_template
-	if i != u.OBJTMPL {
-		entity["category"] = entStr
+	//Check if category and endpoint match, only for objects
+	if i != u.OBJTMPL && i != u.BLDGTMPL && i != u.ROOMTMPL {
+		if entity["category"] != entStr {
+			w.WriteHeader(http.StatusBadRequest)
+			u.Respond(w, u.Message(false, "Category in request body does not correspond with endpoint"))
+			u.ErrLog("Cannot create invalid object", "CREATE "+mux.Vars(r)["entity"], "", r)
+			return
+		}
 	}
 
 	//Clean the data of 'id' attribute if present


### PR DESCRIPTION
Add successful message for bldg template.
Stop overwriting category. For templates, it accepts category sent in payload. For others, checks if it matches endpoint.